### PR TITLE
Add support for IgnoreLike and string[] on globIgnore

### DIFF
--- a/packages/build-graphql/src/core/graphql/findGraphQLFiles.ts
+++ b/packages/build-graphql/src/core/graphql/findGraphQLFiles.ts
@@ -1,8 +1,9 @@
 import { glob } from 'glob';
 import path from 'path';
 import type { GraphqlFile } from './types';
+import { GlobIgnore } from '../types';
 
-export const findGraphQLFiles = async (options: { globPattern: string; globIgnore: string }): Promise<GraphqlFile[]> => {
+export const findGraphQLFiles = async (options: { globPattern: string; globIgnore: GlobIgnore }): Promise<GraphqlFile[]> => {
   const files = await glob(options.globPattern, { ignore: options.globIgnore });
   return files.map((file, index) => ({
     path: path.join(process.cwd(), file).replace(/\\/g, '/'),

--- a/packages/build-graphql/src/core/graphql/findGraphQLFiles.ts
+++ b/packages/build-graphql/src/core/graphql/findGraphQLFiles.ts
@@ -1,9 +1,9 @@
 import { glob } from 'glob';
 import path from 'path';
+import type { FindOptions } from '../types';
 import type { GraphqlFile } from './types';
-import { GlobIgnore } from '../types';
 
-export const findGraphQLFiles = async (options: { globPattern: string; globIgnore: GlobIgnore }): Promise<GraphqlFile[]> => {
+export const findGraphQLFiles = async (options: FindOptions): Promise<GraphqlFile[]> => {
   const files = await glob(options.globPattern, { ignore: options.globIgnore });
   return files.map((file, index) => ({
     path: path.join(process.cwd(), file).replace(/\\/g, '/'),

--- a/packages/build-graphql/src/core/graphql/loadVirtualModule.ts
+++ b/packages/build-graphql/src/core/graphql/loadVirtualModule.ts
@@ -1,9 +1,9 @@
-import { GlobIgnore, ILogger } from '../types';
+import type { FindOptions, ILogger } from '../types';
 import { findGraphQLFiles } from './findGraphQLFiles';
 import { generateTypedefsFile } from './generateTypedefsFile';
 import type { TransformResult } from './types';
 
-export const loadVirtualModule = async (options: { globPattern: string; globIgnore: GlobIgnore }, logger: ILogger): Promise<TransformResult> => {
+export const loadVirtualModule = async (options: FindOptions, logger: ILogger): Promise<TransformResult> => {
   const files = await findGraphQLFiles(options);
   const code = generateTypedefsFile(files);
   logger.debug(`Typedefs: \`${code}\``);

--- a/packages/build-graphql/src/core/graphql/loadVirtualModule.ts
+++ b/packages/build-graphql/src/core/graphql/loadVirtualModule.ts
@@ -1,9 +1,9 @@
-import type { ILogger } from '../types';
+import { GlobIgnore, ILogger } from '../types';
 import { findGraphQLFiles } from './findGraphQLFiles';
 import { generateTypedefsFile } from './generateTypedefsFile';
 import type { TransformResult } from './types';
 
-export const loadVirtualModule = async (options: { globPattern: string; globIgnore: string }, logger: ILogger): Promise<TransformResult> => {
+export const loadVirtualModule = async (options: { globPattern: string; globIgnore: GlobIgnore }, logger: ILogger): Promise<TransformResult> => {
   const files = await findGraphQLFiles(options);
   const code = generateTypedefsFile(files);
   logger.debug(`Typedefs: \`${code}\``);

--- a/packages/build-graphql/src/core/types.ts
+++ b/packages/build-graphql/src/core/types.ts
@@ -1,4 +1,5 @@
 import type { DocumentNode } from 'graphql';
+import type { IgnoreLike } from 'glob';
 
 export interface Options {
   /**
@@ -8,7 +9,7 @@ export interface Options {
   /**
    * Glob ignore pattern for graphql files
    */
-  globIgnore?: string;
+  globIgnore?: string | string[] | IgnoreLike;
   /**
    * Ignores errors, otherwise errors will be thrown if graphql files are not found/imported and the typedefs file is not found
    */

--- a/packages/build-graphql/src/core/types.ts
+++ b/packages/build-graphql/src/core/types.ts
@@ -1,11 +1,15 @@
+import type { GlobOptions, glob } from 'glob';
 import type { DocumentNode } from 'graphql';
-import type { IgnoreLike } from 'glob';
 
+export type GlobPattern = Parameters<typeof glob>[0]; // string | string[]
+export type GlobIgnore = NonNullable<GlobOptions['ignore']>; // string | string[] | IgnoreLike
+
+// TODO(shellicar): Add ability to pass through all glob options
 export interface Options {
   /**
    * Glob pattern to search for graphql files
    */
-  globPattern?: string;
+  globPattern?: GlobPattern;
   /**
    * Glob ignore pattern for graphql files
    */
@@ -25,7 +29,7 @@ export interface Options {
   mapDocumentNode?: (documentNode: DocumentNode) => DocumentNode;
 }
 
-export type GlobIgnore = IgnoreLike | string[] | string;
+export type FindOptions = Required<Pick<Options, 'globPattern' | 'globIgnore'>>;
 
 export type LogLevel = 'debug' | 'error';
 

--- a/packages/build-graphql/src/core/types.ts
+++ b/packages/build-graphql/src/core/types.ts
@@ -9,7 +9,7 @@ export interface Options {
   /**
    * Glob ignore pattern for graphql files
    */
-  globIgnore?: string | string[] | IgnoreLike;
+  globIgnore?: GlobIgnore;
   /**
    * Ignores errors, otherwise errors will be thrown if graphql files are not found/imported and the typedefs file is not found
    */
@@ -24,6 +24,8 @@ export interface Options {
    */
   mapDocumentNode?: (documentNode: DocumentNode) => DocumentNode;
 }
+
+export type GlobIgnore = IgnoreLike | string[] | string;
 
 export type LogLevel = 'debug' | 'error';
 


### PR DESCRIPTION
Adds support for `IgnoreLike` and `string[]` on `globIgnore` option, in addition to `string`.

Fixes: https://github.com/shellicar/build-graphql/issues/22