### PR TITLE
Add globOptions and deprecate globIgnore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # Changelog
 
-## [1.2.3] - 2025-05-01
+## [1.3.0] - 2026-01-05
+
+### Added
+
+- Added `globOptions` to support passing all glob options directly when finding GraphQL files
 
 ### Changed
 
 - Adds support for `IgnoreLike` and `string[]` on `globIgnore` option, in addition to `string`.
+
+### Deprecated
+
+- `globIgnore` is now deprecated in favor of using `globOptions.ignore`
 
 ## [1.2.2] - 2025-12-26
 
@@ -58,7 +66,7 @@ Fix missing README
 
 Initial release.
 
-[1.2.3]: https://github.com/shellicar/build-graphql/releases/tag/1.2.3
+[1.3.0]: https://github.com/shellicar/build-graphql/releases/tag/1.3.0
 [1.2.2]: https://github.com/shellicar/build-graphql/releases/tag/1.2.2
 [1.2.1]: https://github.com/shellicar/build-graphql/releases/tag/1.2.1
 [1.2.0]: https://github.com/shellicar/build-graphql/releases/tag/1.2.0

--- a/biome.json
+++ b/biome.json
@@ -22,15 +22,34 @@
     "enabled": true,
     "rules": {
       "recommended": true,
+      "correctness": {
+        "noUnusedImports": "error",
+        "noUnusedVariables": "error"
+      },
       "suspicious": {
-        "noExplicitAny": "info"
+        "noExplicitAny": "info",
+        "noConsole": "error",
+        "noDebugger": "error"
       },
       "style": {
         "useBlockStatements": "error",
-        "noNonNullAssertion": "warn"
+        "noNonNullAssertion": "warn",
+        "useConst": "error"
       }
     }
   },
+  "overrides": [
+    {
+      "includes": ["examples/**", "**/test/**", "**/createLogger.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    }
+  ],
   "graphql": {
     "formatter": {
       "enabled": true

--- a/packages/build-graphql/package.json
+++ b/packages/build-graphql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shellicar/build-graphql",
   "private": false,
-  "version": "1.2.3-preview.1",
+  "version": "1.3.0",
   "type": "module",
   "license": "MIT",
   "author": "Stephen Hellicar",
@@ -193,7 +193,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "type-check": "tsc -p tsconfig.check.json"
+    "type-check": "tsc -p tsconfig.check.json",
+    "test": "vitest run"
   },
   "peerDependencies": {
     "@farmfe/core": ">=1",

--- a/packages/build-graphql/src/core/findFiles.ts
+++ b/packages/build-graphql/src/core/findFiles.ts
@@ -1,0 +1,6 @@
+import { glob } from 'glob';
+import type { FindOptions } from './types';
+
+export const findFiles = async (options: FindOptions): Promise<string[]> => {
+  return await glob(options.pattern, options.options);
+};

--- a/packages/build-graphql/src/core/graphql/findGraphQLFiles.ts
+++ b/packages/build-graphql/src/core/graphql/findGraphQLFiles.ts
@@ -1,10 +1,10 @@
-import { glob } from 'glob';
 import path from 'path';
+import { findFiles } from '../findFiles';
 import type { FindOptions } from '../types';
 import type { GraphqlFile } from './types';
 
 export const findGraphQLFiles = async (options: FindOptions): Promise<GraphqlFile[]> => {
-  const files = await glob(options.globPattern, { ignore: options.globIgnore });
+  const files = await findFiles(options);
   return files.map((file, index) => ({
     path: path.join(process.cwd(), file).replace(/\\/g, '/'),
     name: `gql_${index}`,

--- a/packages/build-graphql/src/core/index.ts
+++ b/packages/build-graphql/src/core/index.ts
@@ -1,18 +1,26 @@
-import { glob } from 'glob';
 import type { UnpluginFactory } from 'unplugin';
 import { createUnplugin } from 'unplugin';
 import { createLogger } from './createLogger';
 import { defaults } from './defaults';
+import { findFiles } from './findFiles';
 import { loadGraphqlModule } from './graphql/loadGraphqlModule';
 import { loadVirtualModule } from './graphql/loadVirtualModule';
 import { virtualModuleId } from './module';
-import type { Options } from './types';
+import type { FindOptions, Options } from './types';
 
 const resolveVirtualId = (id: string) => `\0${id}`;
 
 const graphqlPluginFactory: UnpluginFactory<Options> = (inputOptions) => {
   const options = { ...defaults, ...inputOptions };
   const logger = createLogger(options);
+
+  const findOptions = {
+    pattern: options.globPattern,
+    options: {
+      ignore: options.globIgnore,
+      ...options.globOptions,
+    },
+  } satisfies FindOptions;
 
   let graphqlMatched: string[] = [];
   const graphqlImports: string[] = [];
@@ -25,7 +33,7 @@ const graphqlPluginFactory: UnpluginFactory<Options> = (inputOptions) => {
     enforce: 'pre',
 
     async buildStart() {
-      graphqlMatched = await glob(options.globPattern, { ignore: options.globIgnore });
+      graphqlMatched = await findFiles(findOptions);
       logger.debug('Matched GraphQL files:', graphqlMatched);
     },
 
@@ -38,7 +46,7 @@ const graphqlPluginFactory: UnpluginFactory<Options> = (inputOptions) => {
     async load(id) {
       if (id === resolveVirtualId(virtualModuleId)) {
         importedTypedefs = true;
-        return await loadVirtualModule(options, logger);
+        return await loadVirtualModule(findOptions, logger);
       }
 
       const result = await loadGraphqlModule(id, options, logger);

--- a/packages/build-graphql/src/core/types.ts
+++ b/packages/build-graphql/src/core/types.ts
@@ -1,4 +1,4 @@
-import type { GlobOptions, glob } from 'glob';
+import type { GlobOptions, GlobOptionsWithFileTypesUnset, glob } from 'glob';
 import type { DocumentNode } from 'graphql';
 
 export type GlobPattern = Parameters<typeof glob>[0]; // string | string[]
@@ -12,8 +12,15 @@ export interface Options {
   globPattern?: GlobPattern;
   /**
    * Glob ignore pattern for graphql files
+   * @deprecated Use `globOptions.ignore` instead
    */
   globIgnore?: GlobIgnore;
+
+  /**
+   * Glob options to pass to the glob library
+   */
+  globOptions?: GlobOptionsWithFileTypesUnset;
+
   /**
    * Ignores errors, otherwise errors will be thrown if graphql files are not found/imported and the typedefs file is not found
    */
@@ -29,7 +36,10 @@ export interface Options {
   mapDocumentNode?: (documentNode: DocumentNode) => DocumentNode;
 }
 
-export type FindOptions = Required<Pick<Options, 'globPattern' | 'globIgnore'>>;
+export type FindOptions = {
+  pattern: GlobPattern;
+  options: GlobOptionsWithFileTypesUnset;
+};
 
 export type LogLevel = 'debug' | 'error';
 

--- a/packages/build-graphql/test/mutation.graphql
+++ b/packages/build-graphql/test/mutation.graphql
@@ -1,0 +1,3 @@
+type Mutation {
+  update: String
+}

--- a/packages/build-graphql/test/pass-glob-ignore.spec.ts
+++ b/packages/build-graphql/test/pass-glob-ignore.spec.ts
@@ -1,0 +1,110 @@
+import { build } from 'esbuild';
+import { readFile } from 'fs/promises';
+import { describe, expect, it } from 'vitest';
+import graphqlPlugin from '../src/esbuild';
+import type { Options } from '../src/types';
+
+type TestFile = 'query.graphql' | 'mutation.graphql' | 'schema.spec.graphql' | 'sub/schema.graphql';
+
+describe('glob ignore', () => {
+  const buildWithOptions = async (options: Options, outfile: string) => {
+    await build({
+      entryPoints: ['test/test-entry.ts'],
+      outfile,
+      bundle: true,
+      platform: 'node',
+      plugins: [graphqlPlugin(options)],
+    });
+    return await readFile(outfile, 'utf-8');
+  };
+
+  const verifyFiles = (output: string, expectedFiles: TestFile[], excludedFiles: TestFile[] = []) => {
+    for (const file of expectedFiles) {
+      expect(output).toContain(file);
+    }
+    for (const file of excludedFiles) {
+      expect(output).not.toContain(file);
+    }
+  };
+
+  it('includes all graphql files', async () => {
+    const output = await buildWithOptions({ globPattern: 'test/**/*.graphql' }, 'test/dist/out.js');
+
+    const expectedFiles = ['query.graphql', 'mutation.graphql', 'schema.spec.graphql', 'sub/schema.graphql'] satisfies TestFile[];
+    verifyFiles(output, expectedFiles);
+  });
+
+  it('can ignore a single file', async () => {
+    const output = await buildWithOptions(
+      {
+        globPattern: 'test/**/*.graphql',
+        globIgnore: '**/mutation.graphql',
+      },
+      'test/dist/out2.js',
+    );
+
+    const expectedFiles = ['query.graphql', 'schema.spec.graphql', 'sub/schema.graphql'] satisfies TestFile[];
+    const excludedFiles = ['mutation.graphql'] satisfies TestFile[];
+    verifyFiles(output, expectedFiles, excludedFiles);
+  });
+
+  it('can ignore multiple files with array', async () => {
+    const output = await buildWithOptions(
+      {
+        globPattern: 'test/**/*.graphql',
+        globIgnore: ['**/mutation.graphql', '**/schema.spec.graphql'],
+      },
+      'test/dist/out3.js',
+    );
+
+    const expectedFiles = ['query.graphql', 'sub/schema.graphql'] satisfies TestFile[];
+    const excludedFiles = ['mutation.graphql', 'schema.spec.graphql'] satisfies TestFile[];
+    verifyFiles(output, expectedFiles, excludedFiles);
+  });
+
+  it('can use glob.ignore syntax', async () => {
+    const output = await buildWithOptions(
+      {
+        globPattern: 'test/**/*.graphql',
+        globOptions: {
+          ignore: '**/mutation.graphql',
+        },
+      },
+      'test/dist/out4.js',
+    );
+
+    const expectedFiles = ['query.graphql', 'schema.spec.graphql', 'sub/schema.graphql'] satisfies TestFile[];
+    const excludedFiles = ['mutation.graphql'] satisfies TestFile[];
+    verifyFiles(output, expectedFiles, excludedFiles);
+  });
+
+  it('glob.ignore overrides globIgnore', async () => {
+    const output = await buildWithOptions(
+      {
+        globPattern: 'test/**/*.graphql',
+        globIgnore: '**/mutation.graphql',
+        globOptions: {
+          ignore: '**/schema.spec.graphql',
+        },
+      },
+      'test/dist/out5.js',
+    );
+
+    const expectedFiles = ['query.graphql', 'mutation.graphql', 'sub/schema.graphql'] satisfies TestFile[];
+    const excludedFiles = ['schema.spec.graphql'] satisfies TestFile[];
+    verifyFiles(output, expectedFiles, excludedFiles);
+  });
+
+  it('baseline: specific pattern matches expected files without ignore', async () => {
+    const output = await buildWithOptions(
+      {
+        globPattern: 'test/*.graphql',
+      },
+      'test/dist/out6.js',
+    );
+
+    const expectedFiles = ['query.graphql', 'mutation.graphql', 'schema.spec.graphql'] satisfies TestFile[];
+    const excludedFiles = ['sub/schema.graphql'] satisfies TestFile[];
+    verifyFiles(output, expectedFiles, excludedFiles);
+  });
+});

--- a/packages/build-graphql/test/pass-glob-ignore.spec.ts
+++ b/packages/build-graphql/test/pass-glob-ignore.spec.ts
@@ -1,5 +1,4 @@
 import { build } from 'esbuild';
-import { readFile } from 'fs/promises';
 import { describe, expect, it } from 'vitest';
 import graphqlPlugin from '../src/esbuild';
 import type { Options } from '../src/types';
@@ -7,15 +6,15 @@ import type { Options } from '../src/types';
 type TestFile = 'query.graphql' | 'mutation.graphql' | 'schema.spec.graphql' | 'sub/schema.graphql';
 
 describe('glob ignore', () => {
-  const buildWithOptions = async (options: Options, outfile: string) => {
-    await build({
+  const buildWithOptions = async (options: Options) => {
+    const result = await build({
       entryPoints: ['test/test-entry.ts'],
-      outfile,
       bundle: true,
       platform: 'node',
       plugins: [graphqlPlugin(options)],
+      write: false,
     });
-    return await readFile(outfile, 'utf-8');
+    return result.outputFiles[0].text;
   };
 
   const verifyFiles = (output: string, expectedFiles: TestFile[], excludedFiles: TestFile[] = []) => {
@@ -28,20 +27,17 @@ describe('glob ignore', () => {
   };
 
   it('includes all graphql files', async () => {
-    const output = await buildWithOptions({ globPattern: 'test/**/*.graphql' }, 'test/dist/out.js');
+    const output = await buildWithOptions({ globPattern: 'test/**/*.graphql' });
 
     const expectedFiles = ['query.graphql', 'mutation.graphql', 'schema.spec.graphql', 'sub/schema.graphql'] satisfies TestFile[];
     verifyFiles(output, expectedFiles);
   });
 
   it('can ignore a single file', async () => {
-    const output = await buildWithOptions(
-      {
-        globPattern: 'test/**/*.graphql',
-        globIgnore: '**/mutation.graphql',
-      },
-      'test/dist/out2.js',
-    );
+    const output = await buildWithOptions({
+      globPattern: 'test/**/*.graphql',
+      globIgnore: '**/mutation.graphql',
+    });
 
     const expectedFiles = ['query.graphql', 'schema.spec.graphql', 'sub/schema.graphql'] satisfies TestFile[];
     const excludedFiles = ['mutation.graphql'] satisfies TestFile[];
@@ -49,13 +45,10 @@ describe('glob ignore', () => {
   });
 
   it('can ignore multiple files with array', async () => {
-    const output = await buildWithOptions(
-      {
-        globPattern: 'test/**/*.graphql',
-        globIgnore: ['**/mutation.graphql', '**/schema.spec.graphql'],
-      },
-      'test/dist/out3.js',
-    );
+    const output = await buildWithOptions({
+      globPattern: 'test/**/*.graphql',
+      globIgnore: ['**/mutation.graphql', '**/schema.spec.graphql'],
+    });
 
     const expectedFiles = ['query.graphql', 'sub/schema.graphql'] satisfies TestFile[];
     const excludedFiles = ['mutation.graphql', 'schema.spec.graphql'] satisfies TestFile[];
@@ -63,15 +56,12 @@ describe('glob ignore', () => {
   });
 
   it('can use globOptions.ignore syntax', async () => {
-    const output = await buildWithOptions(
-      {
-        globPattern: 'test/**/*.graphql',
-        globOptions: {
-          ignore: '**/mutation.graphql',
-        },
+    const output = await buildWithOptions({
+      globPattern: 'test/**/*.graphql',
+      globOptions: {
+        ignore: '**/mutation.graphql',
       },
-      'test/dist/out4.js',
-    );
+    });
 
     const expectedFiles = ['query.graphql', 'schema.spec.graphql', 'sub/schema.graphql'] satisfies TestFile[];
     const excludedFiles = ['mutation.graphql'] satisfies TestFile[];
@@ -79,16 +69,13 @@ describe('glob ignore', () => {
   });
 
   it('globOptions.ignore overrides globIgnore', async () => {
-    const output = await buildWithOptions(
-      {
-        globPattern: 'test/**/*.graphql',
-        globIgnore: '**/mutation.graphql',
-        globOptions: {
-          ignore: '**/schema.spec.graphql',
-        },
+    const output = await buildWithOptions({
+      globPattern: 'test/**/*.graphql',
+      globIgnore: '**/mutation.graphql',
+      globOptions: {
+        ignore: '**/schema.spec.graphql',
       },
-      'test/dist/out5.js',
-    );
+    });
 
     const expectedFiles = ['query.graphql', 'mutation.graphql', 'sub/schema.graphql'] satisfies TestFile[];
     const excludedFiles = ['schema.spec.graphql'] satisfies TestFile[];
@@ -96,12 +83,9 @@ describe('glob ignore', () => {
   });
 
   it('baseline: specific pattern matches expected files without ignore', async () => {
-    const output = await buildWithOptions(
-      {
-        globPattern: 'test/*.graphql',
-      },
-      'test/dist/out6.js',
-    );
+    const output = await buildWithOptions({
+      globPattern: 'test/*.graphql',
+    });
 
     const expectedFiles = ['query.graphql', 'mutation.graphql', 'schema.spec.graphql'] satisfies TestFile[];
     const excludedFiles = ['sub/schema.graphql'] satisfies TestFile[];

--- a/packages/build-graphql/test/pass-glob-ignore.spec.ts
+++ b/packages/build-graphql/test/pass-glob-ignore.spec.ts
@@ -62,7 +62,7 @@ describe('glob ignore', () => {
     verifyFiles(output, expectedFiles, excludedFiles);
   });
 
-  it('can use glob.ignore syntax', async () => {
+  it('can use globOptions.ignore syntax', async () => {
     const output = await buildWithOptions(
       {
         globPattern: 'test/**/*.graphql',
@@ -78,7 +78,7 @@ describe('glob ignore', () => {
     verifyFiles(output, expectedFiles, excludedFiles);
   });
 
-  it('glob.ignore overrides globIgnore', async () => {
+  it('globOptions.ignore overrides globIgnore', async () => {
     const output = await buildWithOptions(
       {
         globPattern: 'test/**/*.graphql',

--- a/packages/build-graphql/test/query.graphql
+++ b/packages/build-graphql/test/query.graphql
@@ -1,0 +1,3 @@
+type Query {
+  hello: String
+}

--- a/packages/build-graphql/test/schema.spec.graphql
+++ b/packages/build-graphql/test/schema.spec.graphql
@@ -1,0 +1,3 @@
+type Spec {
+  test: String
+}

--- a/packages/build-graphql/test/sub/schema.graphql
+++ b/packages/build-graphql/test/sub/schema.graphql
@@ -1,0 +1,3 @@
+type SubType {
+  field: String
+}

--- a/packages/build-graphql/test/test-entry.ts
+++ b/packages/build-graphql/test/test-entry.ts
@@ -1,0 +1,3 @@
+import typedefs from '@shellicar/build-graphql/typedefs';
+
+console.log(JSON.stringify(typedefs));

--- a/packages/build-graphql/vitest.config.ts
+++ b/packages/build-graphql/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
This PR builds on @zfarrugia-ea's work in #24, extending glob configuration capabilities by adding `globOptions` to pass any glob options directly. `globIgnore` is now deprecated in favor of `globOptions.ignore`.